### PR TITLE
ZMI-49: Fixed Incorrect Estimated Tax on Shopping Cart vs Invoice - Sale Transaction Returned Tax

### DIFF
--- a/Model/Extend/ShippingDetails.php
+++ b/Model/Extend/ShippingDetails.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+/**
+ *  Copyright © Above The Fray Design, Inc. All rights reserved.
+ *  See ATF_COPYING.txt for license details.
+ */
+
+namespace ATF\Zamp\Model\Extend;
+
+use ATF\Zamp\Model\Configurations;
+use Magento\Quote\Model\Quote\Address\Total;
+use Magento\Tax\Api\Data\QuoteDetailsItemInterface;
+
+class ShippingDetails
+{
+    /**
+     * @var Configurations
+     */
+    private Configurations $configurations;
+
+    /**
+     * @param Configurations $configurations
+     */
+    public function __construct(
+        Configurations $configurations
+    ) {
+        $this->configurations = $configurations;
+    }
+
+    /**
+     * Add shipping product tax code to include the shipping in tax calculation
+     *
+     * @param QuoteDetailsItemInterface $quoteDetailsItem
+     * @param Total $total
+     * @return QuoteDetailsItemInterface
+     */
+    public function execute(
+        QuoteDetailsItemInterface $quoteDetailsItem,
+        Total $total
+    ): QuoteDetailsItemInterface {
+        if ($extensionAttributes = $quoteDetailsItem->getExtensionAttributes()) {
+            if ($total->getShippingTaxCalculationAmount() !== null) {
+                $extensionAttributes->setProductTaxCode(
+                    $this->configurations->getDefaultProductTaxProviderTaxCode()
+                );
+                $quoteDetailsItem->setExtensionAttributes($extensionAttributes);
+            }
+        }
+
+        return $quoteDetailsItem;
+    }
+}

--- a/Plugin/Tax/Model/Sales/Total/Quote/CommonTaxCollectorShipping.php
+++ b/Plugin/Tax/Model/Sales/Total/Quote/CommonTaxCollectorShipping.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+/**
+ *  Copyright © Above The Fray Design, Inc. All rights reserved.
+ *  See ATF_COPYING.txt for license details.
+ */
+
+namespace ATF\Zamp\Plugin\Tax\Model\Sales\Total\Quote;
+
+use ATF\Zamp\Model\Extend\ShippingDetails;
+use Magento\Quote\Api\Data\ShippingAssignmentInterface;
+use Magento\Quote\Model\Quote\Address\Total;
+use Magento\Tax\Api\Data\QuoteDetailsItemInterface;
+use Magento\Tax\Model\Sales\Total\Quote\CommonTaxCollector;
+
+class CommonTaxCollectorShipping
+{
+    /**
+     * @var ShippingDetails
+     */
+    private ShippingDetails $shippingDetails;
+
+    /**
+     * @param ShippingDetails $shippingDetails
+     */
+    public function __construct(
+        ShippingDetails $shippingDetails
+    ) {
+        $this->shippingDetails = $shippingDetails;
+    }
+
+    /**
+     * After Get Shipping Data Object
+     *
+     * @param CommonTaxCollector $subject
+     * @param QuoteDetailsItemInterface $result
+     * @param ShippingAssignmentInterface $shippingAssignment
+     * @param Total $total
+     * @return QuoteDetailsItemInterface
+     */
+    public function afterGetShippingDataObject(
+        CommonTaxCollector               $subject,
+        QuoteDetailsItemInterface        $result,
+        ShippingAssignmentInterface      $shippingAssignment,
+        Total                            $total
+    ): QuoteDetailsItemInterface {
+        return $this->shippingDetails->execute($result, $total);
+    }
+}

--- a/Preference/Model/TaxCalculation.php
+++ b/Preference/Model/TaxCalculation.php
@@ -144,6 +144,7 @@ class TaxCalculation extends \Magento\Tax\Model\TaxCalculation
     ) {
         $doZampCalc = $this->zampConfigurations->isModuleEnabled()
             && $this->zampConfigurations->isCalculationEnabled()
+            && is_object($quoteDetails->getShippingAddress())
             && $this->zampConfigurations->isTaxableState($quoteDetails->getShippingAddress());
 
         $this->setZampCalculation($doZampCalc);

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "abovethefray/module-zamp",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "N/A",
   "type": "magento2-module",
   "require": {

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -37,6 +37,8 @@
                 type="ATF\Zamp\Plugin\Tax\Model\Sales\Total\Quote\CommonTaxCollectorMapItemProduct"/>
         <plugin name="atf_zamp_plugin_common_tax_apply_quote"
                 type="ATF\Zamp\Plugin\Tax\Model\Sales\Total\Quote\CommonTaxCollectorQuote"/>
+        <plugin name="atf_zamp_plugin_common_tax_apply_shipping"
+                type="ATF\Zamp\Plugin\Tax\Model\Sales\Total\Quote\CommonTaxCollectorShipping"/>
     </type>
     <type name="Magento\Tax\Model\Calculation">
         <plugin name="atf_zamp_plugin_model_calculation_request_cache_key"


### PR DESCRIPTION
- Implemented fixes for the discrepancy between Estimated Tax on the Shopping Cart and the Invoice (Sale Transaction Returned Tax).
- Applied fixes related to the patch referenced in [GitHub Issue #5](https://github.com/zamptax/zamptax-adobe-commerce-extension/issues/5).